### PR TITLE
Add Flow typedefs

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,0 +1,14 @@
+[ignore]
+
+[include]
+
+[libs]
+./flow-typed
+
+[lints]
+
+[options]
+module.file_ext=.js
+module.file_ext=.jsx
+
+[strict]

--- a/devtools/index.js.flow
+++ b/devtools/index.js.flow
@@ -1,0 +1,7 @@
+import {Store} from '..';
+
+declare export default {
+  <State>(store: Store<State>): void;
+  (): <State>(store: Store<State>) => void;
+};
+

--- a/devtools/logger.browser.js.flow
+++ b/devtools/logger.browser.js.flow
@@ -1,0 +1,3 @@
+import { Module } from "..";
+
+declare export default Module<*>;

--- a/devtools/logger.js.flow
+++ b/devtools/logger.js.flow
@@ -1,0 +1,3 @@
+import { Module } from "..";
+
+declare export default Module<*>;

--- a/index.js.flow
+++ b/index.js.flow
@@ -1,0 +1,20 @@
+// @flow
+
+type PropertyKey = string | number | Symbol;
+
+export type Dispatch = (event: PropertyKey, data?: any) => void;
+
+export type Store<State> = {
+  on: (
+    event: PropertyKey,
+    handler: (state: State, data: any) => $Shape<State> | Promise<void> | null
+  ) => () => void;
+  dispatch: Dispatch;
+  get: () => State;
+}
+
+export type Module<State> = (store: Store<State>) => void;
+
+declare export default function createStore<State>(
+  modules: Array<Module<State> | false>
+): Store<State>;

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "eslint-plugin-security": "^1.4.0",
     "eslint-plugin-standard": "^4.0.0",
     "flow-bin": "^0.98.0",
+    "flown": "^0.3.1",
     "husky": "^2.1.0",
     "jest": "^24.7.1",
     "lint-staged": "^8.1.5",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "eslint-plugin-promise": "^4.1.1",
     "eslint-plugin-security": "^1.4.0",
     "eslint-plugin-standard": "^4.0.0",
+    "flow-bin": "^0.98.0",
     "husky": "^2.1.0",
     "jest": "^24.7.1",
     "lint-staged": "^8.1.5",
@@ -137,8 +138,5 @@
       "UIBook",
       "UI"
     ]
-  },
-  "dependencies": {
-    "flow-bin": "^0.98.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "scripts": {
     "clean": "rimraf api.md coverage/",
     "docs": "documentation build *.js react/*.js -f md -o api.md",
+    "flow": "flow",
     "spell": "yarn docs && yaspeller *.md",
     "lint": "eslint *.js test/*.js",
     "typecheck": "tsc -p tsconfig.json --noEmit",
@@ -136,5 +137,8 @@
       "UIBook",
       "UI"
     ]
+  },
+  "dependencies": {
+    "flow-bin": "^0.98.0"
   }
 }

--- a/preact/connect.js.flow
+++ b/preact/connect.js.flow
@@ -1,0 +1,6 @@
+// @flow
+import type {Omit} from 'flown'
+
+declare export default function connect<C>(
+  ...keysOrComponent: Array<$Keys<C> | React$ComponentType<C>>
+): React$ComponentType<$Shape<Omit<C, ["dispatch"]>>>;

--- a/preact/context.js.flow
+++ b/preact/context.js.flow
@@ -1,0 +1,6 @@
+// @flow
+import { type Store } from "..";
+
+declare var StoreContext: React$Context<Store<*>>;
+
+declare export default typeof StoreContext;

--- a/preact/index.js.flow
+++ b/preact/index.js.flow
@@ -1,0 +1,11 @@
+// @flow
+import type {Dispatch} from '..'
+
+export type StoreData<State: {}> = {
+    dispatch: Dispatch;
+} & State
+
+declare export default function useStoreon<State: {}>(
+...keys: Array<$Keys<State>>
+): useStoreon.StoreData<State>;
+

--- a/react/connect.js.flow
+++ b/react/connect.js.flow
@@ -1,0 +1,6 @@
+// @flow
+import type {Omit} from 'flown'
+
+declare export default function connect<C>(
+  ...keysOrComponent: Array<$Keys<C> | React$ComponentType<C>>
+): React$ComponentType<$Shape<Omit<C, ["dispatch"]>>>;

--- a/react/context.js.flow
+++ b/react/context.js.flow
@@ -1,0 +1,6 @@
+// @flow
+import { type Store } from "..";
+
+declare var StoreContext: React$Context<Store<*>>;
+
+declare export default typeof StoreContext;

--- a/react/index.js.flow
+++ b/react/index.js.flow
@@ -1,0 +1,11 @@
+// @flow
+import type {Dispatch} from '..'
+
+export type StoreData<State: {}> = {
+    dispatch: Dispatch;
+} & State
+
+declare export default function useStoreon<State: {}>(
+...keys: Array<$Keys<State>>
+): useStoreon.StoreData<State>;
+

--- a/test/flow/index.js.flow
+++ b/test/flow/index.js.flow
@@ -1,0 +1,59 @@
+// @flow
+import createStore, {type Module, type Store} from '../..'
+import logger from '../../devtools/logger'
+import loggerBrowser from '../../devtools/logger.browser'
+import devtools from '../../devtools'
+
+type State = {
+  a: number,
+  b: string
+}
+
+// Reducer typed as a Module
+const init: Module<State> = (store) => {
+  store.on('@init', () => {
+    return { a: 0, b: '' }
+  })
+}
+
+// Duck-typed reducer
+function setUp(store: Store<State>): void {
+  store.on('inc', (state) => ({ a: state.a + 1 }))
+}
+
+// Store
+const store = createStore<State>([
+  init,
+  setUp,
+  logger,
+  loggerBrowser,
+  devtools,
+  devtools(),
+])
+
+// String event dispatch
+store.dispatch('inc')
+
+// Symbolic event
+const sym = Symbol('sym')
+store.on(sym, (state, data: number) => ({ a: state.a + data }))
+store.dispatch(sym, 2)
+
+// Async reducer
+store.on('comment:post', async (_, data: string) => {
+  store.dispatch('comment:posting')
+
+  try {
+    const response = await fetch('https://github.com', {
+      body: data
+    })
+
+    const result = await response.json()
+    store.dispatch('comment:posted', result)
+  } catch (e) {
+    store.dispatch('comment:error', e)
+  }
+})
+
+const state = store.get()
+state.a

--- a/test/flow/react.js.flow
+++ b/test/flow/react.js.flow
@@ -1,0 +1,50 @@
+// @flow
+import * as ReactDOM from 'react-dom'
+import * as React from 'react'
+import createStore, {type Store} from '../..'
+import useStoreon from '../../react'
+import connect from '../../react/connect'
+import StoreContext from '../../react/context'
+
+type State = {
+  a: number
+}
+
+function init(store: Store<State>) {
+  store.on('@init', () => ({ a: 0 }))
+  store.on('inc', (state, data: number) => ({a: state.a + data}))
+}
+
+const store = createStore([init])
+
+function Button() {
+  const {dispatch, a} = useStoreon<State>('a')
+
+  const onClick = React.useCallback(() => dispatch('inc'), [])
+
+  return (
+    <button onClick={onClick}>Count: {a}</button>
+  )
+}
+
+const App = connect<State>('a', ({a}) => {
+  return (
+    <>
+      <div>Count: {a}</div>
+      <Button/>
+    </>
+  )
+});
+
+const el = document.getElementById("root");
+
+if (el) {
+  ReactDOM.render(
+    <StoreContext.Provider value={store}>
+      <App/>
+    </StoreContext.Provider>,
+    el
+  )
+}
+
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -4355,6 +4355,11 @@ flow-bin@^0.98.0:
   resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.98.0.tgz#3361a03682326a83a5f0a864749f4f7f0d826bce"
   integrity sha512-vuiYjBVt82eYF+dEk9Zqa8hTSDvbhl/czxzFRLZm9/XHbJnYNMTwFoNFYAQT9IQ6ACNBIbwSTIfxroieuKja7g==
 
+flown@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/flown/-/flown-0.3.1.tgz#b3834af4e035b0568fa045737cfb334e0445f7c1"
+  integrity sha512-LZkqdJsnaums6fM6xw88sQnNJCbTkc+c0aFvram5GfUQMArdim12p/9nOxiJ/o/5wHc+yL5G5ZkYzFAStkxyVw==
+
 flush-write-stream@^1.0.0, flush-write-stream@^1.0.2:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/flush-write-stream/-/flush-write-stream-1.1.1.tgz#8dd7d873a1babc207d94ead0c2e0e44276ebf2e8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4350,6 +4350,11 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.0.tgz#55122b6536ea496b4b44893ee2608141d10d9916"
   integrity sha512-R+H8IZclI8AAkSBRQJLVOsxwAoHd6WC40b4QTNWIjzAa6BXOBfQcM587MXDTVPeYaopFNWHUFLx7eNmHDSxMWg==
 
+flow-bin@^0.98.0:
+  version "0.98.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.98.0.tgz#3361a03682326a83a5f0a864749f4f7f0d826bce"
+  integrity sha512-vuiYjBVt82eYF+dEk9Zqa8hTSDvbhl/czxzFRLZm9/XHbJnYNMTwFoNFYAQT9IQ6ACNBIbwSTIfxroieuKja7g==
+
 flush-write-stream@^1.0.0, flush-write-stream@^1.0.2:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/flush-write-stream/-/flush-write-stream-1.1.1.tgz#8dd7d873a1babc207d94ead0c2e0e44276ebf2e8"


### PR DESCRIPTION
For using with [Flow](https://flow.org/en/docs/) `.flow` typedefs needed. PR adds it.