### PR TITLE
Changed typings to make it possible to type actions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,7 +4,7 @@ declare namespace createStore {
   export interface Store<State = unknown> {
     readonly on: (
       event: PropertyKey,
-      handler: (state: Readonly<State>, data: unknown) => Partial<State> | Promise<void> | null
+      handler: (state: Readonly<State>, data: any) => Partial<State> | Promise<void> | null
     ) => () => void;
     readonly dispatch: Dispatch;
     readonly get: () => State;


### PR DESCRIPTION
I think it's reasonable to change `unknown` to `any` there.
It makes it possible to specify event payload type if you know it.

I mean if we have `unknown` - anything we can cast it for is `any` which leads to type loss. But without this cast we must check for existence of any property we want to use. Or in case of primitive we must check the type with typeof, which is superfluous and worthless as I think.

Any can sound bad at first, but the good point is we can cast it directly to the payload type that we know.