### PR TITLE
Moved to useLayoutEffect for subscription

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
         "index.js",
         "react/index.js"
       ],
-      "limit": "330 B",
+      "limit": "353 B",
       "ignore": [
         "react"
       ]
@@ -73,7 +73,7 @@
         "index.js",
         "react/connect.js"
       ],
-      "limit": "389 B",
+      "limit": "410 B",
       "ignore": [
         "react"
       ]

--- a/react/index.js
+++ b/react/index.js
@@ -2,6 +2,9 @@ var React = require('react')
 
 var StoreContext = require('./context')
 
+var useIsomorphicLayoutEffect =
+  typeof window !== 'undefined' ? React.useLayoutEffect : React.useEffect
+
 /**
  * Hook to use Storeon in functional React component.
  *
@@ -27,7 +30,7 @@ module.exports = function () {
   var store = React.useContext(StoreContext)
   var rerender = React.useState({ })
 
-  React.useEffect(function () {
+  useIsomorphicLayoutEffect(function () {
     return store.on('@changed', function (_, changed) {
       var changesInKeys = keys.some(function (key) {
         return key in changed


### PR DESCRIPTION
I've run into a problem using React hook bindings.

When I switch to another tab while page is loading, update is lost.
In my case there is initial state with an empty array and an async action which loads data fired during initialisation. In case of inactive tab store subscription (useEffect) in React hook is fired too late which leads to lost update.

I see new react-redux bindings with hooks are also ran into the similar issues, so they use useLayoutEffect instead of simple useEffect for subscription. I suggest to adopt this solution.

Check: https://github.com/reduxjs/react-redux/blob/v7-hooks-alpha/src/hooks/useSelector.js#L7

Unfortunately, `layout` word costs another 6 bytes so it doesn't pass size-limit :(