### PR TITLE
[Preact] Fix:props frozen on connected child

### DIFF
--- a/preact/connect.js
+++ b/preact/connect.js
@@ -7,10 +7,7 @@ module.exports = function connect () {
   var Component = arguments[arguments.length - 1]
 
   return function (originProps) {
-    var props = useStoreon.apply(null, keys)
-    for (var i in originProps) {
-      if (!(i in props)) props[i] = originProps[i]
-    }
+    var props = Object.assign({ }, originProps, useStoreon.apply(null, keys))
     return Preact.h(Component, props)
   }
 }


### PR DESCRIPTION
closes #55
Copied from [storeon/react/connect.js](https://github.com/storeon/storeon/commit/86782a4a9b7872724770a4f26f9be68392da83e2)