### PR TITLE
Typing improvement: allow reducer to return void

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,7 +4,7 @@ declare namespace createStore {
   export interface Store<State = unknown> {
     readonly on: (
       event: PropertyKey,
-      handler: (state: Readonly<State>, data: any) => Partial<State> | Promise<void> | null
+      handler: (state: Readonly<State>, data: any) => Partial<State> | Promise<void> | null | void
     ) => () => void;
     readonly dispatch: Dispatch;
     readonly get: () => State;


### PR DESCRIPTION
Looks like it is ok to return nothing from reducer function, but TS typing requires `null` at minimal.

Without this fix code like this produces typing error:
```ts
store.on("myEvent", () => {
    const data = doSomeSyncOperation();
    store.dispatch("anotherEvent", data);
}
```