### PR TITLE
updated outdated dependency to fix the build

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "eslint-config-standard": "^12.0.0",
     "eslint-plugin-es5": "^1.3.1",
     "eslint-plugin-import": "^2.17.3",
-    "eslint-plugin-import-helpers": "^0.1.4",
+    "eslint-plugin-import-helpers": "^1.0.1",
     "eslint-plugin-jest": "^22.6.4",
     "eslint-plugin-node": "^9.1.0",
     "eslint-plugin-prefer-let": "^1.0.1",


### PR DESCRIPTION
Current master branch does not build. Eslint fails with the error:

```
Error: <projects>/storeon/node_modules/@logux/eslint-config/base.js:
	Configuration for rule "import-helpers/order-imports" is invalid:
	Value {"groups":[["absolute","module"],["parent","sibling","index"]],"newlinesBetween":"always"} should NOT have additional properties.
```


` "@logux/eslint-config": "^28.2.1"` needs the latest `eslint-plugin-import-helpers` with the new configuration parameters