### PR TITLE
Reduced size of browser logger (2)

### DIFF
--- a/devtools/logger.browser.js
+++ b/devtools/logger.browser.js
@@ -1,28 +1,12 @@
-var print
-if (typeof navigator === 'undefined' || navigator.product === 'ReactNative') {
+var print = console.log
+if (typeof navigator !== 'undefined' && navigator.product !== 'ReactNative') {
   print = function (type, name, opts) {
-    if (opts) {
-      console.log(type + ' ' + name, opts)
-    } else {
-      console.log(type + ' ' + name)
-    }
-  }
-} else {
-  print = function (type, name, opts) {
-    if (opts) {
-      console.log(
-        '%c' + type + ' %c' + name,
-        'color: green',
-        'color: green; font-weight: bold',
-        opts
-      )
-    } else {
-      console.log(
-        '%c' + type + ' %c' + name,
-        'color: green',
-        'color: green; font-weight: bold'
-      )
-    }
+    console.log(
+      '%c' + type + ' %c' + name,
+      'color: #070',
+      'color: #070; font-weight: 700',
+      arguments.length === 2 ? '' : opts
+    )
   }
 }
 

--- a/devtools/logger.browser.js
+++ b/devtools/logger.browser.js
@@ -1,12 +1,20 @@
 var print = console.log
 if (typeof navigator !== 'undefined' && navigator.product !== 'ReactNative') {
   print = function (type, name, opts) {
-    console.log(
-      '%c' + type + ' %c' + name,
-      'color: #070',
-      'color: #070; font-weight: 700',
-      arguments.length === 2 ? '' : opts
-    )
+    if (opts) {
+      console.log(
+        '%c' + type + ' %c' + name,
+        'color: #070',
+        'color: #070; font-weight: 700',
+        opts
+      )
+    } else {
+      console.log(
+        '%c' + type + ' %c' + name,
+        'color: #070',
+        'color: #070; font-weight: 700'
+      )
+    }
   }
 }
 

--- a/devtools/logger.browser.js
+++ b/devtools/logger.browser.js
@@ -10,9 +10,18 @@ if (typeof navigator === 'undefined' || navigator.product === 'ReactNative') {
 } else {
   print = function (type, name, opts) {
     if (opts) {
-      console.log('%c' + type + ' %c' + name, 'color: #008100', 'color: #008100; font-weight: bold', opts)
+      console.log(
+        '%c' + type + ' %c' + name,
+        'color: green',
+        'color: green; font-weight: bold',
+        opts
+      )
     } else {
-      console.log('%c' + type + ' %c' + name, 'color: #008100', 'color: #008100; font-weight: bold')
+      console.log(
+        '%c' + type + ' %c' + name,
+        'color: green',
+        'color: green; font-weight: bold'
+      )
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
         "devtools/index.browser.js",
         "devtools/logger.browser.js"
       ],
-      "limit": "186 B"
+      "limit": "178 B"
     }
   ],
   "eslintConfig": {

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
         "devtools/index.browser.js",
         "devtools/logger.browser.js"
       ],
-      "limit": "192 B"
+      "limit": "190 B"
     }
   ],
   "eslintConfig": {

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
         "devtools/index.browser.js",
         "devtools/logger.browser.js"
       ],
-      "limit": "190 B"
+      "limit": "186 B"
     }
   ],
   "eslintConfig": {

--- a/test/logger.browser.test.js
+++ b/test/logger.browser.test.js
@@ -1,8 +1,8 @@
 var createStore = require('../')
 var logger = require('../devtools/logger.browser')
 
-var STYLE = 'color: green'
-var BOLD = 'color: green; font-weight: bold'
+var STYLE = 'color: #070'
+var BOLD = 'color: #070; font-weight: 700'
 
 function counter (store) {
   store.on('@init', function () {
@@ -18,7 +18,7 @@ it('prints dispatches', function () {
   var store = createStore([counter, logger])
   store.dispatch('inc', 2)
   expect(console.log.mock.calls).toEqual([
-    ['%caction %c@init', STYLE, BOLD],
+    ['%caction %c@init', STYLE, BOLD, ''],
     ['%cchanged %ccount, started', STYLE, BOLD, { count: 0, started: true }],
     ['%caction %cinc', STYLE, BOLD, 2],
     ['%cchanged %ccount', STYLE, BOLD, { count: 2, started: true }]

--- a/test/logger.browser.test.js
+++ b/test/logger.browser.test.js
@@ -1,8 +1,8 @@
 var createStore = require('../')
 var logger = require('../devtools/logger.browser')
 
-var STYLE = 'color: #008100'
-var BOLD = 'color: #008100; font-weight: bold'
+var STYLE = 'color: green'
+var BOLD = 'color: green; font-weight: bold'
 
 function counter (store) {
   store.on('@init', function () {

--- a/test/logger.browser.test.js
+++ b/test/logger.browser.test.js
@@ -18,7 +18,7 @@ it('prints dispatches', function () {
   var store = createStore([counter, logger])
   store.dispatch('inc', 2)
   expect(console.log.mock.calls).toEqual([
-    ['%caction %c@init', STYLE, BOLD, ''],
+    ['%caction %c@init', STYLE, BOLD],
     ['%cchanged %ccount, started', STYLE, BOLD, { count: 0, started: true }],
     ['%caction %cinc', STYLE, BOLD, 2],
     ['%cchanged %ccount', STYLE, BOLD, { count: 2, started: true }]

--- a/test/logger.rn.test.js
+++ b/test/logger.rn.test.js
@@ -5,7 +5,6 @@ Object.defineProperty(navigator, 'product', {
 })
 
 var createStore = require('../')
-var logger = require('../devtools/logger.browser')
 
 function counter (store) {
   store.on('@init', function () {
@@ -17,13 +16,16 @@ function counter (store) {
 }
 
 it('prints dispatches', function () {
+  // mock first as console.log is default method to log
   jest.spyOn(console, 'log').mockImplementation(function () { })
+  // then import logger with console.log
+  var logger = require('../devtools/logger.browser')
   var store = createStore([counter, logger])
   store.dispatch('inc', 2)
   expect(console.log.mock.calls).toEqual([
-    ['action @init'],
-    ['changed count, started', { count: 0, started: true }],
-    ['action inc', 2],
-    ['changed count', { count: 2, started: true }]
+    ['action', '@init'],
+    ['changed', 'count, started', { count: 0, started: true }],
+    ['action', 'inc', 2],
+    ['changed', 'count', { count: 2, started: true }]
   ])
 })


### PR DESCRIPTION
Result: reduced size from `192B` to `178B`

Minor improvements:

- [x] use color hex of length 3
- [x] use font-weight value instead of bold
- [x] use console.log as default method if no style is applied

Extra information:

<img width="456" alt="Screenshot 2019-06-23 at 23 54 26" src="https://user-images.githubusercontent.com/2991847/59981848-3d16e880-9612-11e9-8bdc-a417ae56aa7f.png">