### PR TITLE
fix: pass options to Redux DevTools

### DIFF
--- a/devtools/index.d.ts
+++ b/devtools/index.d.ts
@@ -2,7 +2,7 @@ import {Store} from '..';
 
 declare const devtools: {
   <State>(store: Store<State>): void;
-  (): <State>(store: Store<State>) => void;
+  (options?: object): <State>(store: Store<State>) => void;
 };
 
 export = devtools;

--- a/devtools/index.js
+++ b/devtools/index.js
@@ -13,6 +13,8 @@
  * @function
  */
 function devtools (options) {
+  var isStore = options && options.on && options.dispatch && options.get
+
   function module (store) {
     var extension =
       window.__REDUX_DEVTOOLS_EXTENSION__ ||
@@ -28,7 +30,7 @@ function devtools (options) {
       return
     }
 
-    var ReduxTool = extension.connect()
+    var ReduxTool = extension.connect(isStore ? {} : options)
     store.on('@init', function () {
       ReduxTool.subscribe(function (message) {
         if (message.type === 'DISPATCH' && message.state) {
@@ -65,11 +67,7 @@ function devtools (options) {
     })
   }
 
-  if (options && options.on && options.dispatch && options.get) {
-    return module(options)
-  } else {
-    return module
-  }
+  return isStore ? module(options) : module
 }
 
 module.exports = devtools


### PR DESCRIPTION
Hello,

Thank you for `storeon`! Just replaced redux in one of my packages with storeon and bundle size got 2 smaller by 7kb with no loss in code readability!

I've noticed that after commit 8f2ce10e3f77fbdf33c804fd731def8a73ae6326 `options` passed to storeon/devtools for Redux DevTools are not passed to `extension.connect()`, making impossible to customize DevTools via options.

This PR fixes that and also fixes typings, allowing to pass Redux DevTool options like this:
```typescript
const store = createStore<State, Events>([
  // ...,
  process.env.NODE_ENV !== 'production' && require('storeon/devtools')({
    name: `my-redux-store [${document.title}]`
  })
])
```