### PR TITLE
fix: check for iframes with sameorigin policy set

### DIFF
--- a/devtools/index.js
+++ b/devtools/index.js
@@ -16,10 +16,11 @@ function devtools (options) {
   var isStore = options && options.on && options.dispatch && options.get
 
   function module (store) {
-    var extension =
-      window.__REDUX_DEVTOOLS_EXTENSION__ ||
-      window.top.__REDUX_DEVTOOLS_EXTENSION__
-
+    var extension
+    try {
+      extension = window.__REDUX_DEVTOOLS_EXTENSION__ ||
+        window.top.__REDUX_DEVTOOLS_EXTENSION__
+    } catch (e) {}
     if (!extension) {
       if (process.env.NODE_ENV !== 'production') {
         console.warn(


### PR DESCRIPTION
Hi,

I came across an issue with devtools.  
`DOMException` is being thrown when the code using storeon devtools is opened in an iframe with `X-Frame-Options` header set to `sameorigin` and there is no Redux DevTools installed.

Exception happens because code from storeon devtools is trying to access `window.top` and this action is prohibited from within an iframe (when policy is set to `sameorigin`).

Can you please review this?
Thanks!