### PR TITLE
Make useStoreon hook more type safer (Proposal)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ import useStoreon from 'storeon/react' // or storeon/preact
 
 export default const Counter = () => {
   // Counter will be re-render only on `state.count` changes
-  const { dispatch, count } = useStoreon('count')
+  const { dispatch, count } = useStoreon()('count')
   return <button onClick={() => dispatch('inc')}>{count}</button>
 }
 ```
@@ -212,7 +212,7 @@ For functional components, `useStoreon` hook will be the best option:
 ```js
 import useStoreon from 'storeon/react' // Use 'storeon/preact' for Preact
 const Users = () => {
-  const { dispatch, users, projects } = useStoreon('users', 'projects')
+  const { dispatch, users, projects } = useStoreon()('users', 'projects')
   const onAdd = useCallback(user => {
     dispatch('users/add', user)
   })
@@ -308,7 +308,7 @@ const counterModule: Module<State, Events> = store => {
 const store = createStore<State, Events>([counterModule])
 
 const Counter = () => {
-  const { dispatch, count } = useStoreon<State, Events>('count')
+  const { dispatch, count } = useStoreon<State, Events>()('count')
   // Correct call
   dispatch('set', 100)
   // Compilation error: `set` event do not expect string data

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "storeon",
   "version": "0.9.8",
-  "description": "Tiny (175 bytes) event-based Redux-like state manager for React and Preact",
+  "description": "Tiny (172 bytes) event-based Redux-like state manager for React and Preact",
   "keywords": [
     "state",
     "immutable",
@@ -70,7 +70,7 @@
         "index.js",
         "react/index.js"
       ],
-      "limit": "330 B",
+      "limit": "332 B",
       "ignore": [
         "react"
       ]
@@ -81,7 +81,7 @@
         "index.js",
         "react/connect.js"
       ],
-      "limit": "364 B",
+      "limit": "372 B",
       "ignore": [
         "react"
       ]

--- a/preact/connect.d.ts
+++ b/preact/connect.d.ts
@@ -14,7 +14,7 @@ declare namespace connect {
  * const Counter = ({ count, dispatch }) => {
  *   return <div>
  *     {count}
- *     <button onClick={() => dispatch('inc')}
+ *     <button onClick={() => dispatch('inc')} />
  *   </div>
  * }
  * export default connect('count', Counter)

--- a/preact/connect.js
+++ b/preact/connect.js
@@ -5,7 +5,7 @@ let useStoreon = require('./')
 module.exports = (...keys) => {
   let Component = keys.pop()
   return originProps => {
-    let props = { ...originProps, ...useStoreon(...keys) }
+    let props = { ...originProps, ...useStoreon()(...keys) }
     return Preact.h(Component, props)
   }
 }

--- a/preact/index.d.ts
+++ b/preact/index.d.ts
@@ -1,21 +1,34 @@
 import { Dispatch } from '..'
 
 declare namespace useStoreon {
-  export type StoreData<State extends object = {}, EventsMap = any> = {
+  export type StoreData<State extends object = {}, EventsMap = any, StateKeys extends (keyof State)[] = [keyof State]> = {
     dispatch: Dispatch<EventsMap>
-  } & State
+  } & Pick<State, StateKeys[number]>
 }
 
 /**
- * Hook to use Storeon in functional React component.
+ * Hook to use Storeon in functional Preact component.
  *
  * ```js
  * import useStoreon from 'storeon/preact'
  * const Counter = () => {
- *   const { dispatch, count } = useStoreon('count')
+ *   const { dispatch, count } = useStoreon()('count')
  *   return <div>
  *     {count}
- *     <button onClick={() => dispatch('inc')}
+ *     <button onClick={() => dispatch('inc')} />
+ *   </div>
+ * }
+ * ```
+ * Hook to use Storeon in functional Preact component with Typescript.
+ *
+ * ```ts
+ * import useStoreon from 'storeon/preact'
+ * import { State, Events } from './store'
+ * const Counter = () => {
+ *   const { dispatch, count } = useStoreon<State, Events>()('count')
+ *   return <div>
+ *     {count}
+ *     <button onClick={() => dispatch('inc')} />
  *   </div>
  * }
  * ```
@@ -23,8 +36,8 @@ declare namespace useStoreon {
  * @param keys List of state’s field.
  * @returns The selected part of the state.
  */
-declare function useStoreon<State extends object = {}, EventsMap = any>(
-  ...keys: (keyof State)[]
-): useStoreon.StoreData<State, EventsMap>
+declare function useStoreon<State extends object = {}, EventsMap = any>():
+  <StateKeys extends (keyof State)[]>(...args: StateKeys) =>
+    useStoreon.StoreData<State, EventsMap, StateKeys[][number]>;
 
 export = useStoreon

--- a/preact/index.js
+++ b/preact/index.js
@@ -5,7 +5,7 @@ let StoreContext = require('./context')
 let useIsomorphicLayoutEffect =
   typeof window !== 'undefined' ? hooks.useLayoutEffect : hooks.useEffect
 
-module.exports = (...keys) => {
+module.exports = () => (...keys) => {
   let store = hooks.useContext(StoreContext)
   if (process.env.NODE_ENV !== 'production' && !store) {
     throw new Error(

--- a/react/connect.d.ts
+++ b/react/connect.d.ts
@@ -16,7 +16,7 @@ declare namespace connect {
  * const Counter = ({ count, dispatch }) => {
  *   return <div>
  *     {count}
- *     <button onClick={() => dispatch('inc')}
+ *     <button onClick={() => dispatch('inc')} />
  *   </div>
  * }
  * export default connect('count', Counter)

--- a/react/connect.js
+++ b/react/connect.js
@@ -5,7 +5,7 @@ let useStoreon = require('./')
 module.exports = (...keys) => {
   let Component = keys.pop()
   return originProps => {
-    let props = { ...originProps, ...useStoreon(...keys) }
+    let props = { ...originProps, ...useStoreon()(...keys) }
     return React.createElement(Component, props)
   }
 }

--- a/react/index.d.ts
+++ b/react/index.d.ts
@@ -1,9 +1,9 @@
 import { Dispatch } from '..'
 
 declare namespace useStoreon {
-  export type StoreData<State extends object = {}, EventsMap = any> = {
+  export type StoreData<State extends object = {}, EventsMap = any, StateKeys extends (keyof State)[] = [keyof State]> = {
     dispatch: Dispatch<EventsMap>
-  } & State
+  } & Pick<State, StateKeys[number]>
 }
 
 /**
@@ -12,10 +12,23 @@ declare namespace useStoreon {
  * ```js
  * import useStoreon from 'storeon/react'
  * const Counter = () => {
- *   const { dispatch, count } = useStoreon('count')
+ *   const { dispatch, count } = useStoreon()('count')
  *   return <div>
  *     {count}
- *     <button onClick={() => dispatch('inc')}
+ *     <button onClick={() => dispatch('inc')} />
+ *   </div>
+ * }
+ * ```
+ * Hook to use Storeon in functional React component with Typescript.
+ *
+ * ```ts
+ * import useStoreon from 'storeon/react'
+ * import { State, Events } from './store'
+ * const Counter = () => {
+ *   const { dispatch, count } = useStoreon<State, Events>()('count')
+ *   return <div>
+ *     {count}
+ *     <button onClick={() => dispatch('inc')} />
  *   </div>
  * }
  * ```
@@ -23,8 +36,8 @@ declare namespace useStoreon {
  * @param keys List of state’s field.
  * @returns The selected part of the state.
  */
-declare function useStoreon<State extends object = {}, EventsMap = any>(
-  ...keys: (keyof State)[]
-): useStoreon.StoreData<State, EventsMap>
+declare function useStoreon<State extends object = {}, EventsMap = any>():
+  <StateKeys extends (keyof State)[]>(...args: StateKeys) =>
+    useStoreon.StoreData<State, EventsMap, StateKeys[][number]>;
 
 export = useStoreon

--- a/react/index.js
+++ b/react/index.js
@@ -5,7 +5,7 @@ let StoreContext = require('./context')
 let useIsomorphicLayoutEffect =
   typeof window !== 'undefined' ? React.useLayoutEffect : React.useEffect
 
-module.exports = (...keys) => {
+module.exports = () => (...keys) => {
   let store = React.useContext(StoreContext)
   if (process.env.NODE_ENV !== 'production' && !store) {
     throw new Error(

--- a/test/demo/index.js
+++ b/test/demo/index.js
@@ -28,7 +28,7 @@ function tracker (text) {
 }
 
 function Button1 () {
-  let { dispatch } = useStoreon()
+  let { dispatch } = useStoreon()()
   let onClick = useCallback(() => {
     dispatch('inc1')
   })
@@ -36,7 +36,7 @@ function Button1 () {
 }
 
 function Button2 () {
-  let { dispatch } = useStoreon()
+  let { dispatch } = useStoreon()()
   let onClick = useCallback(() => {
     dispatch('inc2')
   })
@@ -44,17 +44,17 @@ function Button2 () {
 }
 
 function Tracker1 () {
-  let { count1 } = useStoreon('count1')
+  let { count1 } = useStoreon()('count1')
   return tracker(`Counter 1: ${ count1 }`)
 }
 
 function Tracker2 () {
-  let { count2 } = useStoreon('count2')
+  let { count2 } = useStoreon()('count2')
   return tracker(`Counter 2: ${ count2 }`)
 }
 
 function Tracker12 () {
-  let { count1, count2 } = useStoreon('count1', 'count2')
+  let { count1, count2 } = useStoreon()('count1', 'count2')
   return tracker(`Counter 1: ${ count1 }, counter 2: ${ count2 }`)
 }
 

--- a/test/errors.ts
+++ b/test/errors.ts
@@ -1,4 +1,5 @@
-import createStore, {Module, Store, StoreonEvents } from '..'
+import createStore, { Module, Store, StoreonEvents } from '..'
+import useStoreon from '../react'
 
 const sym = Symbol('sym')
 
@@ -87,6 +88,9 @@ store.on('@dispatch', (_, [event, data]) => {
     console.log(data);
   }
 })
+
+// THROWS Property 'b' does not exist on type 'StoreData<State, EventsDataTypesMap, ["a"]>'.
+useStoreon<State, EventsDataTypesMap>()('a').b
 
 s2.get()
 s3.get().a

--- a/test/react.test.js
+++ b/test/react.test.js
@@ -77,7 +77,7 @@ it('allows using Symbol as a store key', () => {
     store.on('sym', state => ({ [sym]: state[sym] + 1 }))
   }
   function Button () {
-    let hooks = useStoreon(sym)
+    let hooks = useStoreon()(sym)
     return hooks[sym]
   }
   let store = createStore([symbol])
@@ -93,7 +93,7 @@ it('allows using Symbol as a store key', () => {
 
 it('throws if there is no StoreProvider', () => {
   function Button () {
-    let hooks = useStoreon('')
+    let hooks = useStoreon()('')
     return hooks
   }
   function render () {

--- a/test/react.types.tsx
+++ b/test/react.types.tsx
@@ -21,7 +21,7 @@ function init(store: Store<State>) {
 const store = createStore<State, EventsDataTypesMap>([init])
 
 function Button() {
-  const { dispatch, a } = useStoreon<State, EventsDataTypesMap>('a')
+  const { dispatch, a } = useStoreon<State, EventsDataTypesMap>()('a')
 
   const onClick = React.useCallback(() => dispatch('inc'), [])
 


### PR DESCRIPTION
This trick helps to make the output from useStoreon hook safer. Using currying helps us provide partial type parameter inference. It can be returned to the normal view when TS Team implements [Partial Type Argument Inference ](https://github.com/microsoft/TypeScript/issues/26242)

**Related topics**
https://stackoverflow.com/questions/57325035/in-typescript-is-it-possible-to-infer-string-literal-types-for-discriminated-uni/57333791#57333791

***Problem***
**Code**
```ts
import { StoreonEvents } from 'storeon'  

interface State {
  a: number
  b: string
}

interface EventsDataTypesMap extends StoreonEvents<State> {
  'inc': undefined;
}

function App() {
  // const a: number
  // const b: string
  const { a, b } = useStoreon<State, EventsDataTypesMap>('a')

  return null
}
```
**Expected behavior:** Error _Property 'b' does not exist on type_ 
**Actual behavior:** b is defined

***Solution***
**Code**
```ts
import { StoreonEvents } from 'storeon'  

interface State {
  a: number
  b: string
}

interface EventsDataTypesMap extends StoreonEvents<State> {
  'inc': undefined;
}

function App() {
  // const a: number
  // Property 'b' does not exist on type
  const { a, b } = useStoreon<State, EventsDataTypesMap>()('a')

  return null
}
```
**Actual behavior:** Error _Property 'b' does not exist on type_