### PR TITLE
Fix devtools import in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,9 +256,11 @@ into `props`. It will re-render only if this keys will be changed.
 Storeon supports debugging with [Redux DevTools Extension].
 
 ```js
+import devtools from 'storeon/devtools';
+
 const store = createStore([
   …
-  process.env.NODE_ENV !== 'production' && require('storeon/devtools').default
+  process.env.NODE_ENV !== 'production' && devtools
 ])
 ```
 
@@ -269,9 +271,11 @@ Or if you want to print events to `console` you can use built-in logger.
 It could be useful for simple cases or to investigate issue in error trackers.
 
 ```js
+ import logger from 'storeon/devtools/logger';
+
 const store = createStore([
   …
-  process.env.NODE_ENV !== 'production' && require('storeon/devtools/logger').default
+  process.env.NODE_ENV !== 'production' && logger
 ])
 ```
 

--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ Or if you want to print events to `console` you can use built-in logger.
 It could be useful for simple cases or to investigate issue in error trackers.
 
 ```js
- import logger from 'storeon/devtools/logger';
+import logger from 'storeon/devtools/logger';
 
 const store = createStore([
   …

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ Storeon supports debugging with [Redux DevTools Extension].
 ```js
 const store = createStore([
   …
-  process.env.NODE_ENV !== 'production' && require('storeon/devtools')
+  process.env.NODE_ENV !== 'production' && require('storeon/devtools').default
 ])
 ```
 
@@ -271,7 +271,7 @@ It could be useful for simple cases or to investigate issue in error trackers.
 ```js
 const store = createStore([
   …
-  process.env.NODE_ENV !== 'production' && require('storeon/devtools/logger')
+  process.env.NODE_ENV !== 'production' && require('storeon/devtools/logger').default
 ])
 ```
 


### PR DESCRIPTION
Since project was rewritten to use ES modules we need to use require(...).default imports.