### PR TITLE
fix: typescript customContext types

### DIFF
--- a/preact/index.d.ts
+++ b/preact/index.d.ts
@@ -74,7 +74,8 @@ export function useStoreon<State extends object = {}, EventsMap = any>(
 export function customContext<
   State extends object = {},
   EventsMap = any
->(context: Context<StoreonStore<State, EventsMap>>): (...keys: (keyof State)[]) => useStoreon.StoreData<State, EventsMap>
+>(context: Context<StoreonStore<State, EventsMap>>):
+  (...keys: (keyof State)[]) => useStoreon.StoreData<State, EventsMap>
 
 /**
  * Context to put store for `connect` decorator.

--- a/preact/index.d.ts
+++ b/preact/index.d.ts
@@ -71,10 +71,10 @@ export function useStoreon<State extends object = {}, EventsMap = any>(
  * @param context User's owned React context
  * @returns useStoreon hooks that attatched to User's React context
  */
-export function customContext(context: Context<StoreonStore>): <
+export function customContext<
   State extends object = {},
   EventsMap = any
->(...keys: (keyof State)[]) => useStoreon.StoreData<State, EventsMap>
+>(context: Context<StoreonStore<State, EventsMap>>): (...keys: (keyof State)[]) => useStoreon.StoreData<State, EventsMap>
 
 /**
  * Context to put store for `connect` decorator.

--- a/react/index.d.ts
+++ b/react/index.d.ts
@@ -69,7 +69,8 @@ export function useStoreon<State extends object = {}, EventsMap = any>(
 export function customContext<
   State extends object = {},
   EventsMap = any
->(context: Context<StoreonStore<State, EventsMap>>): (...keys: (keyof State)[]) => useStoreon.StoreData<State, EventsMap>
+>(context: Context<StoreonStore<State, EventsMap>>):
+  (...keys: (keyof State)[]) => useStoreon.StoreData<State, EventsMap>
 
 /**
  * Context to put store for `connect` decorator.

--- a/react/index.d.ts
+++ b/react/index.d.ts
@@ -66,10 +66,10 @@ export function useStoreon<State extends object = {}, EventsMap = any>(
  * @param context User's owned React context
  * @returns useStoreon hooks that attatched to User's React context
  */
-export function customContext(context: Context<StoreonStore>): <
+export function customContext<
   State extends object = {},
   EventsMap = any
->(...keys: (keyof State)[]) => useStoreon.StoreData<State, EventsMap>
+>(context: Context<StoreonStore<State, EventsMap>>): (...keys: (keyof State)[]) => useStoreon.StoreData<State, EventsMap>
 
 /**
  * Context to put store for `connect` decorator.


### PR DESCRIPTION
TL;DR
---

Move generic to the front.

Before
------

```tsx
import React from 'react'

import { customContext } from 'storeon/react'
import { store, Store, Event } from './storeon'

const StoreonContext = React.createContext(store)

// At this point useStoreon need to be defined generic types when use hooks
// In addition there's a type error `Argument of type 'Context<StoreonStore<Store, Event>>' is not assignable to parameter of type 'Context<StoreonStore<unknown, any>>'.`
export const useStoreon = customContext(StoreonContext)

export const Context: React.FC = props => {
  const { children } = props

  return (
    <StoreonContext.Provider value={store}>
      {children}
    </StoreonContext.Provider>
  )
}
```

```tsx
import React from 'react'

import { useStoreon } from './parent'
import { Store, Event } from './storeon'

const Counter = () => {
  const { dispatch, count } = useStoreon<Store, Event>('count')
  return <div>
    {count}
    <button onClick={() => dispatch('inc')}
  </div>
}
```

After
------

```tsx
import React from 'react'

import { customContext } from 'storeon/react'
import { store } from './storeon'

const StoreonContext = React.createContext(store)

// Hooks automatically recognize types of Storeon instance
// `const useStoreon: (...keys: ("settings" | "collection" | "subtitle")[]) => useStoreon.StoreData<Store, Event>`
export const useStoreon = customContext(StoreonContext)

export const Context: React.FC = props => {
  const { children } = props

  return (
    <StoreonContext.Provider value={store}>
      {children}
    </StoreonContext.Provider>
  )
}
```

```tsx
import React from 'react'

import { useStoreon } from './parent'
import { Store, Event } from './storeon'

const Counter = () => {
  // No need for define types anymore
  const { dispatch, count } = useStoreon('count')
  return <div>
    {count}
    <button onClick={() => dispatch('inc')}
  </div>
}
```