### PR TITLE
fix: definition class StoreonStore to interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,7 +6,7 @@ type DataTypes<Map, Key extends keyof Map> =
 /**
  * Store with application state and event listeners.
  */
-export class StoreonStore<State = unknown, Events = any> {
+export interface StoreonStore<State = unknown, Events = any> {
   /**
    * Add event listener.
    *


### PR DESCRIPTION
HarmonyImportSpecifierDependency trying to find the class StoreonStore. But there is no such function in index.js itself, the StoreonStore must be an interface

related: https://github.com/storeon/angular/pull/34