### PR TITLE
fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,14 @@ Read more about Storeon features in **[our article]**.
 import { createStoreon } from 'storeon'
 
 // Initial state, reducers and business logic are packed in independent modules
-let increment = store => {
+let count = store => {
   // Initial state
   store.on('@init', () => ({ count: 0 }))
   // Reducers returns only changed part of the state
   store.on('inc', ({ count }) => ({ count: count + 1 }))
 }
 
-export const store = createStoreon([increment])
+export const store = createStoreon([count])
 ```
 
 ```js


### PR DESCRIPTION
I think it is more clear to name reducer `count`, because it contains operations with `count`, not just one operation `inc`. It also corresponds to store object key - { count: ... }