### PR TITLE
Adding support for undefined on state type declaration.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -63,7 +63,7 @@ export namespace createStoreon {
   export type EventHandler<
     State, Events, Event extends keyof (Events & StoreonEvents<State, Events>)
   > = (
-    state: Readonly<State>,
+    state: State extends object ? Readonly<State> : State,
     data: (Events & StoreonEvents<State, Events>)[Event]
   ) => Partial<State> | Promise<void> | null | void
 

--- a/test/index.types.ts
+++ b/test/index.types.ts
@@ -47,3 +47,9 @@ store.on('comment:post', async (_, data: string) => {
 
 const state = store.get()
 state.a
+
+// Allows undefined on state type
+let storeA: StoreonStore
+const storeB: StoreonStore<{} | undefined> = {} as any
+storeA = storeB
+storeA.get()


### PR DESCRIPTION
This PR contains change in the typescript declaration which will allows to have state type which can be `undefined`.
The core implementation of storeon in general never operates on the state which can be undefined, but during the work on  [storeon-substore](https://github.com/majo44/storeon-substore) where user is able to create store with the main state projection,  such projection type can have `undefined` union. Eg:

```typescript
import { createStoreon } from "storeon";
import { createSubstore } from "storeon-substore";

interface FooState {... }
interface State {
   foo?: FooState;
}

const store = createStoreon<State>([]);
const fooStore = createSubstore(store, 'foo'); // inferred type is StoreonStore<FooState | undefined, any> as foo is optional
```

This code works fine, but it can't be used when we do not care about state, it is not assignable to `StoreonStore`:

```typescript
let fooGenericStore1: StoreonStore = fooStore;
// TS2322: Type 'StoreonStore<FooState | undefined, any>' is not assignable to type 'StoreonStore<unknown, any>'.   
// Types of property 'on' are incompatible.     
// Type '<Event extends string | number | symbol>(event: Event, handler: EventHandler<FooState | undefined, any, Event>) => () => void' is not assignable to type '<Event extends string | number | symbol>(event: Event, handler: EventHandler<unknown, any, Event>) => () => void'.       
// Types of parameters 'handler' and 'handler' are incompatible.         
// Types of parameters 'state' and 'state' are incompatible.           
// Type 'Readonly<FooState> | undefined' is not assignable to type 'Readonly<unknown>'.             
// Type 'undefined' is not assignable to type 'Readonly<unknown>'. 
```
this cause that it can't be used eg with react `StoreContext`

The problem is that *Type `undefined` is not assignable to type `Readonly<unknown>`* but `undefined` is assignable to `unknown`. So the solution is to use `Readonly` from the handler declaration only for the case when the type is explicite set as some type which extends `object`. In all other cases (`any`, `unknown`, primitives) the `Readonly` is not needed and is causes problems described above.  


This PR do not contains breaking changes.