### PR TITLE
Remove extra variable

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,16 +9,15 @@ let createStoreon = modules => {
       }
 
       if (events[event]) {
-        let changes = {}
-        let changed
+        let changes
         events[event].forEach(i => {
           let diff = events[event].includes(i) && i(state, data, store)
           if (diff && typeof diff.then !== 'function') {
-            changed = state = { ...state, ...diff }
+            state = { ...state, ...diff }
             changes = { ...changes, ...diff }
           }
         })
-        if (changed) store.dispatch('@changed', changes)
+        if (changes) store.dispatch('@changed', changes)
       }
     },
 


### PR DESCRIPTION
Remove unnecessary variable. `undefined` doesn't broke code with spread operator nor `Object.assign()`

```js
let x;

console.log({ ...x }) // {}
console.log( Object.assign({}, x) ) // {}
```